### PR TITLE
Use lightweight eval check in update workflow

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Update flake inputs
         run: nix flake update
 
-      - name: Check flake
-        run: nix flake check
+      - name: Run lightweight CI check
+        run: nix eval .#packages.x86_64-linux.default.drvPath --raw
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
Switch the weekly update workflow to a lightweight eval-only check instead of full flake checks.